### PR TITLE
fix utils

### DIFF
--- a/ultralytics/yolo/utils/__init__.py
+++ b/ultralytics/yolo/utils/__init__.py
@@ -261,7 +261,7 @@ def yaml_save(file='data.yaml', data=None):
     # Convert Path objects to strings
     for k, v in data.items():
         if isinstance(v, Path):
-            dict[k] = str(v)
+            data[k] = str(v)
 
     # Dump data to file in YAML format
     with open(file, 'w') as f:


### PR DESCRIPTION
Error:
```
Ultralytics YOLOv8.0.100 🚀 Python-3.9.13 torch-1.13.1+cu117 CUDA:0 (NVIDIA GeForce RTX 2080 Ti, 11011MiB)
WARNING ⚠️ Upgrade to torch>=2.0.0 for deterministic training.
Traceback (most recent call last):
  File "/yolo/ultralytics/__train__.py", line 84, in <module>
    main(parse_opt())
  File "/yolo/ultralytics/__train__.py", line 57, in main
    model.train(project=opt.project, name=opt.name, patience=0, cache=opt.cache, device=opt.device,
  File "/yolo/ultralytics/venv/lib/python3.9/site-packages/ultralytics/yolo/engine/model.py", line 366, in train
    self.trainer = TASK_MAP[self.task][1](overrides=overrides, _callbacks=self.callbacks)
  File "/yolo/ultralytics/venv/lib/python3.9/site-packages/ultralytics/yolo/v8/classify/train.py", line 22, in __init__
    super().__init__(cfg, overrides, _callbacks)
  File "/yolo/ultralytics/venv/lib/python3.9/site-packages/ultralytics/yolo/engine/trainer.py", line 102, in __init__
    yaml_save(self.save_dir / 'args.yaml', vars(self.args))  # save run args
  File "/yolo/ultralytics/venv/lib/python3.9/site-packages/ultralytics/yolo/utils/__init__.py", line 264, in yaml_save
    dict[k] = str(v)
TypeError: 'type' object does not support item assignment
```